### PR TITLE
Update xiaomi_airpurifier.py REQUIREMENTS

### DIFF
--- a/custom_components/fan/xiaomi_airpurifier.py
+++ b/custom_components/fan/xiaomi_airpurifier.py
@@ -35,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # REQUIREMENTS = ['python-mirobo']
 REQUIREMENTS = ['https://github.com/rytilahti/python-mirobo/archive/'
                 '168f5c0ff381b3b02cedd0917597195b3c521a20.zip#'
-                'python-mirobo']
+                'python-mirobo==0.1.4']
 
 ATTR_TEMPERATURE = 'temperature'
 ATTR_HUMIDITY = 'humidity'


### PR DESCRIPTION
If you have xiaomi vacuum, which requires 0.1.2 

Your requirement satisfied python-mirobo

This will force upgrade to install / upgrade 0.1.4