### PR TITLE
Add dmaker.airfresh.a1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Credits: Thanks to [Rytilahti](https://github.com/rytilahti/python-miio) for all
 | Smartmi Fresh Air System XFXT01ZM        | zhimi.airfresh.va2  | XFXT01ZM     | |
 | Smartmi Fresh Air System XFXTDFR02ZM     | zhimi.airfresh.va4  | XFXTDFR02ZM  | PTC/Heater support |
 | Mi Fresh Air Ventilator  | [dmaker.airfresh.t2017](docs/dmaker-airfresh-t2017.md)  | MJXFJ-300-G1**?** | 300m3/h (Air volume), 35W, 36db(A), 16kg |
+| Mi Fresh Air Ventilator  | dmaker.airfresh.a1  | MJXFJ-150-A1  | 150m<sup>3</sup>/h (Air volume), 20W, 36db(A), 8kg |
 | Pedestal Fan Fan V2    | zhimi.fan.v2           | | |
 | Pedestal Fan Fan V3    | zhimi.fan.v3           | | |
 | Pedestal Fan Fan SA1   | zhimi.fan.sa1          | | |
@@ -430,7 +431,7 @@ This model uses newer MiOT communication protocol.
   - `extra_features`
   - `ptc` (zhimi.airfresh.va4 only)
 
-### Mi Fresh Air Ventilator (dmaker.airfresh.t2017)
+### Mi Fresh Air Ventilator (dmaker.airfresh.t2017, dmaker.airfresh.a1)
 
 This paragraph was moved to [docs/dmaker-airfresh-t2017.md](docs/dmaker-airfresh-t2017.md).
 

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1005,7 +1005,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         device = XiaomiAirFresh(name, air_fresh, model, unique_id)
     elif model == MODEL_AIRFRESH_A1:
         air_fresh = AirFreshA1(host, token, model=model)
-        device = XiaomiAirFreshT2017(name, air_fresh, model, unique_id)
+        device = XiaomiAirFreshA1(name, air_fresh, model, unique_id)
     elif model == MODEL_AIRFRESH_T2017:
         air_fresh = AirFreshT2017(host, token, model=model)
         device = XiaomiAirFreshT2017(name, air_fresh, model, unique_id)

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -495,7 +495,7 @@ AVAILABLE_ATTRIBUTES_AIRFRESH = {
 
 AVAILABLE_ATTRIBUTES_AIRFRESH_VA4 = {**AVAILABLE_ATTRIBUTES_AIRFRESH, ATTR_PTC: "ptc"}
 
-AVAILABLE_ATTRIBUTES_AIRFRESH_T2017 = {
+AVAILABLE_ATTRIBUTES_AIRFRESH_A1 = {
     ATTR_POWER: "power",
     ATTR_MODE: "mode",
     ATTR_PM25: "pm25",
@@ -505,14 +505,18 @@ AVAILABLE_ATTRIBUTES_AIRFRESH_T2017 = {
     ATTR_CONTROL_SPEED: "control_speed",
     ATTR_DUST_FILTER_LIFE_REMAINING: "dust_filter_life_remaining",
     ATTR_DUST_FILTER_LIFE_REMAINING_DAYS: "dust_filter_life_remaining_days",
-    ATTR_UPPER_FILTER_LIFE_REMAINING: "upper_filter_life_remaining",
-    ATTR_UPPER_FILTER_LIFE_REMAINING_DAYS: "upper_filter_life_remaining_days",
     ATTR_PTC: "ptc",
-    ATTR_PTC_LEVEL: "ptc_level",
     ATTR_PTC_STATUS: "ptc_status",
     ATTR_CHILD_LOCK: "child_lock",
     ATTR_BUZZER: "buzzer",
     ATTR_DISPLAY: "display",
+}
+
+AVAILABLE_ATTRIBUTES_AIRFRESH_T2017 = {
+    **AVAILABLE_ATTRIBUTES_AIRFRESH_A1,
+    ATTR_UPPER_FILTER_LIFE_REMAINING: "upper_filter_life_remaining",
+    ATTR_UPPER_FILTER_LIFE_REMAINING_DAYS: "upper_filter_life_remaining_days",
+    ATTR_PTC_LEVEL: "ptc_level",
     ATTR_DISPLAY_ORIENTATION: "display_orientation",
 }
 
@@ -734,6 +738,15 @@ FEATURE_FLAGS_AIRFRESH_VA4 = (
     | FEATURE_RESET_FILTER
     | FEATURE_SET_EXTRA_FEATURES
     | FEATURE_SET_PTC
+)
+
+FEATURE_FLAGS_AIRFRESH_A1 = (
+    FEATURE_SET_BUZZER
+    | FEATURE_SET_CHILD_LOCK
+    | FEATURE_SET_LED
+    | FEATURE_RESET_FILTER
+    | FEATURE_SET_PTC
+    | FEATURE_SET_FAVORITE_SPEED
 )
 
 FEATURE_FLAGS_AIRFRESH_T2017 = (
@@ -990,7 +1003,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     elif model.startswith("zhimi.airfresh."):
         air_fresh = AirFresh(host, token, model=model)
         device = XiaomiAirFresh(name, air_fresh, model, unique_id)
-    elif model in [MODEL_AIRFRESH_A1, MODEL_AIRFRESH_T2017]:
+    elif model == MODEL_AIRFRESH_A1:
+        air_fresh = AirFreshA1(host, token, model=model)
+        device = XiaomiAirFreshT2017(name, air_fresh, model, unique_id)
+    elif model == MODEL_AIRFRESH_T2017:
         air_fresh = AirFreshT2017(host, token, model=model)
         device = XiaomiAirFreshT2017(name, air_fresh, model, unique_id)
     elif model in [
@@ -1932,8 +1948,13 @@ class XiaomiAirFreshT2017(XiaomiAirFresh):
         """Initialize the miio device."""
         super().__init__(name, device, model, unique_id)
 
-        self._available_attributes = AVAILABLE_ATTRIBUTES_AIRFRESH_T2017
-        self._device_features = FEATURE_FLAGS_AIRFRESH_T2017
+        if self._model == MODEL_AIRFRESH_T2017:
+            self._available_attributes = AVAILABLE_ATTRIBUTES_AIRFRESH_T2017
+            self._device_features = FEATURE_FLAGS_AIRFRESH_T2017
+        else:
+            self._available_attributes = AVAILABLE_ATTRIBUTES_AIRFRESH_A1
+            self._device_features = FEATURE_FLAGS_AIRFRESH_A1
+
         self._speed_list = OPERATION_MODES_AIRFRESH_T2017
         self._state_attrs.update(
             {attribute: None for attribute in self._available_attributes}

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -114,6 +114,7 @@ MODEL_AIRHUMIDIFIER_JSQ = "deerma.humidifier.jsq"
 MODEL_AIRHUMIDIFIER_JSQ1 = "deerma.humidifier.jsq1"
 MODEL_AIRHUMIDIFIER_JSQ001 = "shuii.humidifier.jsq001"
 
+MODEL_AIRFRESH_A1 = "dmaker.airfresh.a1"
 MODEL_AIRFRESH_VA2 = "zhimi.airfresh.va2"
 MODEL_AIRFRESH_VA4 = "zhimi.airfresh.va4"
 MODEL_AIRFRESH_T2017 = "dmaker.airfresh.t2017"
@@ -160,6 +161,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 MODEL_AIRHUMIDIFIER_JSQ,
                 MODEL_AIRHUMIDIFIER_JSQ1,
                 MODEL_AIRHUMIDIFIER_JSQ001,
+                MODEL_AIRFRESH_A1,
                 MODEL_AIRFRESH_VA2,
                 MODEL_AIRFRESH_VA4,
                 MODEL_AIRFRESH_T2017,
@@ -988,7 +990,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     elif model.startswith("zhimi.airfresh."):
         air_fresh = AirFresh(host, token, model=model)
         device = XiaomiAirFresh(name, air_fresh, model, unique_id)
-    elif model == MODEL_AIRFRESH_T2017:
+    elif model in [MODEL_AIRFRESH_A1, MODEL_AIRFRESH_T2017]:
         air_fresh = AirFreshT2017(host, token, model=model)
         device = XiaomiAirFreshT2017(name, air_fresh, model, unique_id)
     elif model in [

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -2052,6 +2052,19 @@ class XiaomiAirFreshT2017(XiaomiAirFresh):
         )
 
 
+class XiaomiAirFreshA1(XiaomiAirFreshT2017):
+    """Representation of a Xiaomi Air Fresh A1."""
+    async def async_reset_filter(self):
+        """Reset the filter lifetime and usage."""
+        if self._device_features & FEATURE_RESET_FILTER == 0:
+            return
+
+        await self._try_command(
+            "Resetting filter lifetime of the miio device failed.",
+            self._device.reset_filter,
+        )
+
+
 class XiaomiFan(XiaomiGenericDevice):
     """Representation of a Xiaomi Pedestal Fan."""
 

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -6,6 +6,7 @@ import logging
 
 from miio import (  # pylint: disable=import-error
     AirFresh,
+    AirFreshA1,
     AirFreshT2017,
     AirHumidifier,
     AirHumidifierJsq,

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -2054,6 +2054,7 @@ class XiaomiAirFreshT2017(XiaomiAirFresh):
 
 class XiaomiAirFreshA1(XiaomiAirFreshT2017):
     """Representation of a Xiaomi Air Fresh A1."""
+
     async def async_reset_filter(self):
         """Reset the filter lifetime and usage."""
         if self._device_features & FEATURE_RESET_FILTER == 0:

--- a/custom_components/xiaomi_miio_airpurifier/manifest.json
+++ b/custom_components/xiaomi_miio_airpurifier/manifest.json
@@ -6,7 +6,7 @@
   "issue_tracker": "https://github.com/syssi/xiaomi_airpurifier/issues",
   "requirements": [
     "construct==2.10.56",
-    "python-miio>=0.5.4"
+    "python-miio>=0.5.5"
   ],
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
TODO: 

- set_filter_rate 100 to reset the filter lifetime.
- What about: switch_power, switch_mode, get_sensor, get_speed?

Supported methods:
- [x] `set_power [power]` on/off
- [x]  `set_mode [mode]` sleep/auto/favourite
- [x]  `set_favourite_speed` 0...150
- [ ]  `get_sensor [sensor]` pm25/co2 (at the mihome app pm25 values above 999 are capped to 999)
- [x]  `set_ptc_on [on/off]`
- [ ] `get_timer []`
- [ ] `get_ptc_timer []`
- [ ] `set_ptc_timer [ptcTime]`
- [ ] `set_timer [time]`
- [ ] `get_light_timer []`
- [ ] `set_light_timer [lightTime]`
- [ ] `delete_timer [time]`
- [x] `set_display [light]` on/off(?)
- [x] `set_sound [sound]` on/off
- [x] `set_child_lock [lock]` on/off
- [x] `set_filter_reset [filter]`

Supported properties:

- [x] `pm25`
- [x] `co2`
- [x] `temperature_outside`
- [x] `favourite_speed`
- [x] `filter_rate`
- [x] `filter_day`
- [x] `control_speed`
- [x] `power`
- [x] `mode`
- [x] `ptc_on`
- [x] `ptc_status`
- [x] `child_lock`
- [x] `sound`
- [x] `display`
 
Getter and setter of `ptc_level` and `screen_direction` is not supported!

Example `get_prop` response:

```
$ miiocli device --ip IP --token TOKEN raw_command get_prop '["power", "pm25", "co2", "temperature_outside", "favourite_speed", "filter_rate", "filter_day", "control_speed", "ptc_on", "ptc_status", "child_lock", "sound", "display", "mode"]'
Running command raw_command
[True, 2, 554, 12, 150, 45, 81, 60, False, False, False, False, False, 'auto']
```