### PR TITLE
Removed Wet Protection preset mode for deerma.humidifier.mjjsq

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1877,7 +1877,9 @@ class XiaomiAirHumidifierMjjsq(XiaomiAirHumidifier):
             self._device_features = FEATURE_FLAGS_AIRHUMIDIFIER_MJJSQ
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRHUMIDIFIER_MJJSQ
 
-        self._preset_modes = [mode.name for mode in AirhumidifierMjjsqOperationMode]
+        self._preset_modes = [mode.name for mode in AirhumidifierMjjsqOperationMode
+                              if self._device_features & FEATURE_SET_WET_PROTECTION != 0
+                              or mode != AirhumidifierMjjsqOperationMode.WetAndProtect]
         self._state_attrs = {ATTR_MODEL: self._model}
         self._state_attrs.update(
             {attribute: None for attribute in self._available_attributes}


### PR DESCRIPTION
deerma.humidifier.mjjsq and deerma.humidifier.jsq don't support wet protection mode.
Remove it from preset_mode