### PR TITLE
Use Host and Token to generate unique_id

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/climate.py
+++ b/custom_components/xiaomi_miio_airpurifier/climate.py
@@ -139,7 +139,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     model = config.get(CONF_MODEL)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
-    unique_id = None
+    unique_id = f"{host}-{token[:5]}"
 
     if model is None:
         miio_device = Device(host, token)
@@ -149,7 +149,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             raise PlatformNotReady
 
         model = device_info.model
-        unique_id = "{}-{}".format(model, device_info.mac_address)
         _LOGGER.info(
             "%s %s %s detected",
             model,

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1107,14 +1107,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     retries = config[CONF_RETRIES]
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
-    unique_id = None
+    unique_id = f"{host}-{token[:5]}"
 
     if model is None:
         try:
             miio_device = Device(host, token)
             device_info = await hass.async_add_executor_job(miio_device.info)
             model = device_info.model
-            unique_id = f"{model}-{device_info.mac_address}"
             _LOGGER.info(
                 "%s %s %s detected",
                 model,


### PR DESCRIPTION
Use combination of the host and last 5 digits of the token to create a unique ID that should always be available and remain relatively constant (assuming a static IP address is assigned).

Should resolve the issue where model number and MAC address are not always known if the device is turned off and the unique_id is not generated if a model number is specified. 

Fixes #412 