### PR TITLE
Fix fan turn_on percentage and preset mode handling

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -4,6 +4,7 @@ import asyncio
 from enum import Enum
 from functools import partial
 import logging
+from typing import Any
 
 from homeassistant.components.fan import PLATFORM_SCHEMA, FanEntity, FanEntityFeature
 from homeassistant.const import (
@@ -1344,27 +1345,23 @@ class XiaomiGenericDevice(FanEntity):
 
     async def async_turn_on(
         self,
-        speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Turn the device on."""
-        result = await self._try_command(
-            "Turning the miio device on failed.", self._device.on
-        )
-
-        if not result:
-            return
-
-        self._state = True
-        self._skip_update = True
 
         if percentage is not None:
             await self.async_set_percentage(percentage)
-
-        if preset_mode is not None:
+        elif preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
+        else:
+            await self._try_command(
+                "Turning the miio device on failed.", self._device.on
+            )
+
+        self._state = True
+        self._skip_update = True
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""
@@ -3268,14 +3265,12 @@ class XiaomiAirDog(XiaomiGenericDevice):
 
     async def async_turn_on(
         self,
-        speed: str | None = None,
         percentage: int | None = None,
         preset_mode: str | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Turn the device on."""
         await super().async_turn_on(
-            speed=speed,
             percentage=percentage,
             preset_mode=preset_mode,
             **kwargs,

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1350,17 +1350,21 @@ class XiaomiGenericDevice(FanEntity):
         **kwargs,
     ) -> None:
         """Turn the device on."""
-        if preset_mode:
-            # If operation mode was set the device must not be turned on.
-            result = await self.async_set_preset_mode(preset_mode)
-        else:
-            result = await self._try_command(
-                "Turning the miio device on failed.", self._device.on
-            )
+        result = await self._try_command(
+            "Turning the miio device on failed.", self._device.on
+        )
 
-        if result:
-            self._state = True
-            self._skip_update = True
+        if not result:
+            return
+
+        self._state = True
+        self._skip_update = True
+
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""
@@ -3270,10 +3274,12 @@ class XiaomiAirDog(XiaomiGenericDevice):
         **kwargs,
     ) -> None:
         """Turn the device on."""
-        await super().async_turn_on(speed, percentage, preset_mode, **kwargs)
-
-        self._state = True
-        self._skip_update = True
+        await super().async_turn_on(
+            speed=speed,
+            percentage=percentage,
+            preset_mode=preset_mode,
+            **kwargs,
+        )
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the device off."""


### PR DESCRIPTION
Fix fan async_turn_on() so HΑ percentage and preset_mode arguments are applied after the device is turned on.

Previously percentage was ignored and preset_mode handling relied on setters that usually return None.