### PR TITLE
Fix dehumidifier humidity auto mode switch

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/climate.py
+++ b/custom_components/xiaomi_miio_airpurifier/climate.py
@@ -532,7 +532,7 @@ class XiaomiAirDehumidifier(XiaomiGenericDevice):
     async def async_set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         if self.preset_mode != AirdehumidifierOperationMode.Auto.name:
-            await self.async_set_preset_mode(AirdehumidifierOperationMode.Auto)
+            await self.async_set_preset_mode(AirdehumidifierOperationMode.Auto.name)
 
         humidity = round(humidity / 10) * 10
         await self._try_command(


### PR DESCRIPTION
Fix async_set_humidity() to pass the Auto preset name instead of the enum object.
The preset setter expects a string key, so passing the enum can fail before humidity is updated :( .