### PR TITLE
Handle missing dehumidifier mode in supported features

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/climate.py
+++ b/custom_components/xiaomi_miio_airpurifier/climate.py
@@ -415,8 +415,12 @@ class XiaomiAirDehumidifier(XiaomiGenericDevice):
         if self.hvac_mode == HVACMode.OFF:
             return features
 
+        mode_value = self._state_attrs.get(ATTR_MODE)
+        if mode_value is None:
+            return features
+
         features |= ClimateEntityFeature.PRESET_MODE
-        mode = AirdehumidifierOperationMode(self._state_attrs[ATTR_MODE])
+        mode = AirdehumidifierOperationMode(mode_value)
         if mode == AirdehumidifierOperationMode.Auto:
             features |= ClimateEntityFeature.TARGET_HUMIDITY
         if mode != AirdehumidifierOperationMode.DryCloth:

--- a/custom_components/xiaomi_miio_airpurifier/climate.py
+++ b/custom_components/xiaomi_miio_airpurifier/climate.py
@@ -415,11 +415,10 @@ class XiaomiAirDehumidifier(XiaomiGenericDevice):
         if self.hvac_mode == HVACMode.OFF:
             return features
 
+        features |= ClimateEntityFeature.PRESET_MODE
         mode_value = self._state_attrs.get(ATTR_MODE)
         if mode_value is None:
             return features
-
-        features |= ClimateEntityFeature.PRESET_MODE
         mode = AirdehumidifierOperationMode(mode_value)
         if mode == AirdehumidifierOperationMode.Auto:
             features |= ClimateEntityFeature.TARGET_HUMIDITY
@@ -498,7 +497,10 @@ class XiaomiAirDehumidifier(XiaomiGenericDevice):
     @property
     def preset_mode(self):
         """Return the current preset mode, e.g., home, away, temp."""
-        return AirdehumidifierOperationMode(self._state_attrs[ATTR_MODE]).name
+        mode_value = self._state_attrs.get(ATTR_MODE)
+        if mode_value is None:
+            return None
+        return AirdehumidifierOperationMode(mode_value).name
 
     @property
     def fan_mode(self):


### PR DESCRIPTION
Guard dehumidifier supported_features against a missing mode value.

If the device is on but mode has not been populated yet, converting None to OperationMode can crash the entity. Return only the base turn on/off features until a valid mode is available.