### PR TITLE
Fix yamllint errors in YAML doc files

### DIFF
--- a/docs/dmaker.airfresh.a1.yaml
+++ b/docs/dmaker.airfresh.a1.yaml
@@ -20,7 +20,7 @@ switch:
           data:
             entity_id: fan.xiaomi_fresh_air_ventilator
         icon_template: mdi:lightbulb-outline
-        
+
       xiaomi_fresh_air_ventilator_child_lock:
         friendly_name: Child lock
         value_template: "{{ is_state_attr('fan.xiaomi_fresh_air_ventilator', 'child_lock', True) }}"
@@ -33,7 +33,7 @@ switch:
           data:
             entity_id: fan.xiaomi_fresh_air_ventilator
         icon_template: mdi:lock-outline
-        
+
       xiaomi_fresh_air_ventilator_buzzer:
         friendly_name: Buzzer
         value_template: "{{ is_state_attr('fan.xiaomi_fresh_air_ventilator', 'buzzer', True) }}"
@@ -46,7 +46,7 @@ switch:
           data:
             entity_id: fan.xiaomi_fresh_air_ventilator
         icon_template: mdi:volume-high
-        
+
       xiaomi_fresh_air_ventilator_ptc:
         friendly_name: PTC
         value_template: "{{ is_state_attr('fan.xiaomi_fresh_air_ventilator', 'ptc', True) }}"
@@ -59,7 +59,7 @@ switch:
           data:
             entity_id: fan.xiaomi_fresh_air_ventilator
         icon_template: mdi:fire
-  
+
 sensor:
   - platform: template
     sensors:
@@ -68,40 +68,40 @@ sensor:
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.co2 }}'
         unit_of_measurement: 'ppm'
         icon_template: mdi:molecule-co2
-        
+
       xiaomi_fresh_air_ventilator_pm25:
         friendly_name: PM2.5
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.pm25 }}'
         unit_of_measurement: 'µg/m³'
         icon_template: mdi:grain
-        
+
       xiaomi_fresh_air_ventilator_temperature:
         friendly_name: Temperature
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.temperature }}'
         unit_of_measurement: '°C'
         icon_template: mdi:thermometer
-        
+
       xiaomi_fresh_air_ventilator_current_speed:
         friendly_name: Current speed
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.control_speed }}'
         icon_template: mdi:speedometer
-        
+
       xiaomi_fresh_air_ventilator_favorite_speed:
         friendly_name: Favorite speed
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.favorite_speed }}'
         icon_template: mdi:speedometer
-        
+
       xiaomi_fresh_air_ventilator_ptc_status:
         friendly_name: PTC status
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.ptc_status }}'
         icon_template: mdi:lightning-bolt
-        
+
       xiaomi_fresh_air_ventilator_dust_filter_life_remaining:
         friendly_name: Dust filter life remaining
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.dust_filter_life_remaining }}'
         unit_of_measurement: '%'
         icon_template: mdi:air-filter
-        
+
       xiaomi_fresh_air_ventilator_dust_filter_life_remaining_days:
         friendly_name: Dust filter life remaining days
         value_template: '{{ states.fan.xiaomi_fresh_air_ventilator.attributes.dust_filter_life_remaining_days }}'
@@ -153,7 +153,7 @@ automation:
       data_template:
         entity_id: fan.xiaomi_fresh_air_ventilator
         preset_mode: '{{ states.input_select.xiaomi_fresh_air_ventilator_mode.state }}'
-        
+
   - alias: Monitor operation mode and update input select
     trigger:
       platform: state
@@ -164,4 +164,4 @@ automation:
       data_template:
         option: >
           {% if states.fan.xiaomi_fresh_air_ventilator.attributes.preset_mode %} {{ states.fan.xiaomi_fresh_air_ventilator.attributes.preset_mode }} {% else %}Auto{% endif %}
-          
+

--- a/docs/zhimi.humidifier.ca1.yaml
+++ b/docs/zhimi.humidifier.ca1.yaml
@@ -52,7 +52,7 @@ sensor:
     sensors:
       humidifier_water_level:
         friendly_name: Water level
-        value_template: '{{ (states.fan.humidifier.attributes.depth / 125 * 100) | round() }}' # provides value in [0, ..., 125]
+        value_template: '{{ (states.fan.humidifier.attributes.depth / 125 * 100) | round() }}'  # provides value in [0, ..., 125]
         unit_of_measurement: '%'
         icon_template: mdi:waves
 
@@ -80,7 +80,7 @@ input_select:
   humidifier_led:
     name: Led mode
     options:
-      - 'Off' # will be converted to False without quotes
+      - 'Off'  # will be converted to False without quotes
       - Dim
       - Bright
 


### PR DESCRIPTION
## Summary

- Add missing second space before inline comments in `zhimi.humidifier.ca1.yaml` (lines 55 and 83)
- Remove trailing spaces from `dmaker.airfresh.a1.yaml` (lines 23, 36, 49, 62, 71, 77, 83, 88, 93, 98, 104, 156, 167)

## Test plan
- [ ] Run yamllint on both files to confirm no remaining errors