### PR TITLE
Fix fan turn_on off-state handling

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1423,15 +1423,21 @@ class XiaomiGenericDevice(FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the device on."""
+        if percentage == 0 or preset_mode == SPEED_OFF:
+            await self.async_turn_off(**kwargs)
+            return
 
         if percentage is not None:
             await self.async_set_percentage(percentage)
         elif preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
         else:
-            await self._try_command(
+            result = await self._try_command(
                 "Turning the miio device on failed.", self._device.on
             )
+
+            if not result:
+                return
 
         self._state = True
         self._skip_update = True


### PR DESCRIPTION
Fix fan async_turn_on() handling for off-like values.

Previously, calling fan.turn_on with percentage=0 or preset_mode="off" could call async_turn_off(), but then still mark the entity as on by setting _state to True.

This now returns immediately for those off like values and only marks the entity as on when a normal turn on command succeeds or a non off percentage/preset mode is applied.