### PR TITLE
Handle missing dehumidifier fan mode

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/climate.py
+++ b/custom_components/xiaomi_miio_airpurifier/climate.py
@@ -507,7 +507,12 @@ class XiaomiAirDehumidifier(XiaomiGenericDevice):
         """Return the fan setting."""
         if self.preset_mode == AirdehumidifierOperationMode.DryCloth.name:
             return None
-        return AirdehumidifierFanSpeed(self._state_attrs[ATTR_FAN_ST]).name
+
+        fan_speed = self._state_attrs.get(ATTR_FAN_ST)
+        if fan_speed is None:
+            return None
+
+        return AirdehumidifierFanSpeed(fan_speed).name
 
     @property
     def fan_modes(self):


### PR DESCRIPTION
Guard the dehumidifier fan_mode property against a missing fan_st value.

The entity already handles a missing mode value in supported_features and preset_mode, but fan_mode still converted fan_st directly to AirdehumidifierFanSpeed. If fan_st is not populated yet, this can raise an exception.

Return None until a valid fan mode value is available.