### PR TITLE
Fix AirDog X7SM Speed 5 mode value

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -3181,12 +3181,12 @@ class XiaomiAirDog(XiaomiGenericDevice):
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRPURIFIER_AIRDOG_X3
 
         self._preset_modes_to_mode_speed = {
-            "Auto": (AirDogOperationMode("auto"), 1),
-            "Night mode": (AirDogOperationMode("sleep"), 1),
-            "Speed 1": (AirDogOperationMode("manual"), 1),
-            "Speed 2": (AirDogOperationMode("manual"), 2),
-            "Speed 3": (AirDogOperationMode("manual"), 3),
-            "Speed 4": (AirDogOperationMode("manual"), 4),
+            "Auto": (AirDogOperationMode.Auto, 1),
+            "Night mode": (AirDogOperationMode.Idle, 1),
+            "Speed 1": (AirDogOperationMode.Manual, 1),
+            "Speed 2": (AirDogOperationMode.Manual, 2),
+            "Speed 3": (AirDogOperationMode.Manual, 3),
+            "Speed 4": (AirDogOperationMode.Manual, 4),
         }
         if self._model == MODEL_AIRPURIFIER_AIRDOG_X7SM:
             self._preset_modes_to_mode_speed["Speed 5"] = (

--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -3190,7 +3190,7 @@ class XiaomiAirDog(XiaomiGenericDevice):
         }
         if self._model == MODEL_AIRPURIFIER_AIRDOG_X7SM:
             self._preset_modes_to_mode_speed["Speed 5"] = (
-                AirDogOperationMode("Manual"),
+                AirDogOperationMode.Manual,
                 5,
             )
 


### PR DESCRIPTION
Fix the AirDog X7SM Speed 5 preset mode mapping.

The code used AirDogOperationMode("Manual"), but the enum value is "manual". This can raise a ValueError when initializing the X7SM preset modes.

Use AirDogOperationMode.Manual instead, matching the existing enum value and the other manual speed mappings.