### PR TITLE
Handle Fan 1C off preset mode

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -3080,6 +3080,10 @@ class XiaomiFan1C(XiaomiFan):
         """Set the preset mode of the fan."""
         _LOGGER.debug("Setting the preset mode to: %s", preset_mode)
 
+        if preset_mode == SPEED_OFF:
+            await self.async_turn_off()
+            return
+
         if not self._state:
             await self._try_command(
                 "Turning the miio device on failed.", self._device.on


### PR DESCRIPTION
Handle the Fan 1C "off" preset mode by turning the device off directly.

Previously, selecting the "off" preset could turn the device on first and then call set_speed(0). Other fan implementations already handle the off preset through async_turn_off(), and Fan 1C should do the same.