### PR TITLE
Honor retries setting for classic air purifiers

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -1223,7 +1223,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         device = XiaomiAirPurifierMiot(name, air_purifier, model, unique_id, retries)
     elif model.startswith("zhimi.airpurifier."):
         air_purifier = AirPurifier(host, token)
-        device = XiaomiAirPurifier(name, air_purifier, model, unique_id)
+        device = XiaomiAirPurifier(name, air_purifier, model, unique_id, retries)
     elif model in HUMIDIFIER_MIOT:
         air_humidifier = AirHumidifierMiot(host, token)
         device = XiaomiAirHumidifierMiot(name, air_humidifier, model, unique_id)


### PR DESCRIPTION
## Summary

Make classic `zhimi.airpurifier.*` devices honor the configured retry count before being marked unavailable.

## Problem

`XiaomiAirPurifier` already implements retry handling through `self._retries`, but its constructor was created without the configured `retries` value.

As a result, the class silently used the default value of `0`, causing a single transient polling failure to mark the entity unavailable immediately.

## Fix

Pass the existing `retries` setting to the `XiaomiAirPurifier` constructor, consistent with the sibling device classes that use the same retry logic.