### PR TITLE
Fix JSQ1 WetAndProtect preset mode

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -2035,7 +2035,7 @@ class XiaomiAirHumidifierMjjsq(XiaomiAirHumidifier):
         await self._try_command(
             "Setting preset mode of the miio device failed.",
             self._device.set_mode,
-            AirhumidifierMjjsqOperationMode[preset_mode.title()],
+            AirhumidifierMjjsqOperationMode[preset_mode],
         )
 
     async def async_set_wet_protection_on(self):


### PR DESCRIPTION
## Summary

Fix the `WetAndProtect` preset mode for the Xiaomi JSQ1 humidifier.

## Problem

Preset modes are already exposed using the exact names from `AirhumidifierMjjsqOperationMode`.

The setter applied `.title()` before looking up the enum value, which transformed:

`WetAndProtect` → `Wetandprotect`

Since that enum member does not exist, selecting the mode raised a `KeyError`.

## Fix

Use the preset mode name directly when looking up the enum member.

Other modes such as `Low`, `Medium`, `High`, and `Humidity` are unaffected.