### PR TITLE
Fix Fan 1C percentage when turned off

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/fan.py
+++ b/custom_components/xiaomi_miio_airpurifier/fan.py
@@ -3056,6 +3056,8 @@ class XiaomiFan1C(XiaomiFan):
     @property
     def percentage(self) -> int | None:
         """Return the current speed percentage."""
+        if not self._state or self._preset_mode == SPEED_OFF:
+            return 0
         return ordered_list_item_to_percentage(FAN_SPEEDS_1C, self._preset_mode)
 
     @property


### PR DESCRIPTION
## Summary

Fix percentage reporting for the Xiaomi Fan 1C when the fan is turned off.

## Problem

`FAN_SPEEDS_1C` intentionally excludes the `off` preset, but the entity can still have `SPEED_OFF` as its current preset mode when the device reports speed `0`.

Home Assistant may still read the `percentage` property while the fan is off, causing `ordered_list_item_to_percentage()` to raise `ValueError`.

## Fix

Return `0%` when the fan is off or the current preset mode is `SPEED_OFF`.

Normal speed percentage calculation remains unchanged.