### PR TITLE
Avoid blocking device info lookup in climate setup

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/climate.py
+++ b/custom_components/xiaomi_miio_airpurifier/climate.py
@@ -145,7 +145,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if model is None:
         miio_device = Device(host, token)
         try:
-            device_info = miio_device.info()
+            device_info = await hass.async_add_executor_job(miio_device.info)
         except DeviceException:
             raise PlatformNotReady from None
 


### PR DESCRIPTION
## Summary

Avoid blocking the Home Assistant event loop during climate platform setup.

## Problem

`async_setup_platform()` called `miio_device.info()` directly inside an async coroutine.

`Device.info()` performs synchronous network I/O, so the call could block the Home Assistant event loop while waiting for the device.

## Fix

Run the existing `miio_device.info()` call through `hass.async_add_executor_job()`, matching the pattern already used by the fan platform.

Existing `DeviceException` and `PlatformNotReady` handling remains unchanged.