### PR TITLE
Relax construct dependency constraint

### DIFF
--- a/custom_components/xiaomi_miio_airpurifier/manifest.json
+++ b/custom_components/xiaomi_miio_airpurifier/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/syssi/xiaomi_airpurifier",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/syssi/xiaomi_airpurifier/issues",
-  "requirements": ["construct==2.10.68", "python-miio>=0.5.12"],
+  "requirements": ["construct>=2.10.68,<3.0.0", "python-miio>=0.5.12"],
   "version": "2026.6.0.0"
 }


### PR DESCRIPTION
## Summary

Relax the `construct` dependency from an exact version pin to a compatible version range.

## Problem

The integration pinned:

`construct==2.10.68`

even though `python-miio` supports:

`construct>=2.10.56,<3.0.0`

The integration does not use `construct` directly, so the exact pin unnecessarily blocks compatible patch releases.

## Fix

Allow compatible `construct` releases while keeping the existing minimum version:

`construct>=2.10.68,<3.0.0`